### PR TITLE
Datasharing: add append param

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 
 [bumpversion:file:DESCRIPTION]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rportal
 Title: UMCCR Portal R Functions
 Description: Contains R functionality for interacting with the UMCCR Data Portal.
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Peter", "Diakumis", , "peterdiakumis@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7502-7545"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,8 +24,7 @@ knitr::knit_hooks$set(
 require(rportal)
 ```
 
-# 🔮 rportal - Interacting with the UMCCR Portal
-
+# 🔮 rportal - Interacting with the UMCCR Data Portal
 
 ## 🍕 Installation
 
@@ -43,7 +42,7 @@ bioinformatics data (FASTQs, BAMs, VCFs and HTMLs/TSVs):
 ### Bioinformatics Data Sharing
 
 A `datashare.R` command line interface is available for convenience.
-You need to export the `rportal/inst/datashare/` directory to your `PATH` in order to use `datashare.R`:
+You need to export the `rportal/inst/scripts/datashare/` directory to your `PATH` in order to use `datashare.R`:
 
 ```{bash eval=FALSE, echo=TRUE}
 datashare_cli=$(Rscript -e 'x = system.file("scripts/datashare", package = "rportal"); cat(x, "\n")' | xargs)
@@ -54,6 +53,8 @@ export PATH="${datashare_cli}:${PATH}"
 datashare_cli=$(Rscript -e 'x = system.file("scripts/datashare", package = "rportal"); cat(x, "\n")' | xargs)
 export PATH="${datashare_cli}:${PATH}"
 
+echo "datashare.R --version" & datashare.R --version
+echo ""
 echo "#-----------------------------------#"
 echo "datashare.R --help" & datashare.R --help
 echo ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-- [🔮 rportal - Interacting with the UMCCR
-  Portal](#-rportal---interacting-with-the-umccr-portal)
+- [🔮 rportal - Interacting with the UMCCR Data
+  Portal](#-rportal---interacting-with-the-umccr-data-portal)
   - [🍕 Installation](#-installation)
   - [🌀 CLI](#-cli)
     - [Bioinformatics Data Sharing](#bioinformatics-data-sharing)
@@ -8,7 +8,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# 🔮 rportal - Interacting with the UMCCR Portal
+# 🔮 rportal - Interacting with the UMCCR Data Portal
 
 ## 🍕 Installation
 
@@ -25,13 +25,16 @@ URLs for bioinformatics data (FASTQs, BAMs, VCFs and HTMLs/TSVs):
 ### Bioinformatics Data Sharing
 
 A `datashare.R` command line interface is available for convenience. You
-need to export the `rportal/inst/datashare/` directory to your `PATH` in
-order to use `datashare.R`:
+need to export the `rportal/inst/scripts/datashare/` directory to your
+`PATH` in order to use `datashare.R`:
 
 ``` bash
 datashare_cli=$(Rscript -e 'x = system.file("scripts/datashare", package = "rportal"); cat(x, "\n")' | xargs)
 export PATH="${datashare_cli}:${PATH}"
 ```
+
+    datashare.R --version
+    0.1.0 
 
     #-----------------------------------#
     datashare.R --help
@@ -50,7 +53,13 @@ export PATH="${datashare_cli}:${PATH}"
             Library ID of tumor.
 
     --csv_output=CSV_OUTPUT
-            CSV output path (def: ./urls_<subject_id>__<library_id_tumor>.csv).
+            CSV output path.
+
+    --append
+            Append to existing file (or write to new one if file does not exist -- caution: no column headers are written).
+
+    --version, -v
+            Print rportal version and exit.
 
     --help, -h
             Show this help message and exit

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export PATH="${datashare_cli}:${PATH}"
 ```
 
     datashare.R --version
-    0.1.0 
+    0.1.1 
 
     #-----------------------------------#
     datashare.R --help

--- a/inst/scripts/datashare/datashare.R
+++ b/inst/scripts/datashare/datashare.R
@@ -4,7 +4,7 @@ suppressMessages(library(optparse, include.only = "make_option"))
 option_list <- list(
   optparse::make_option("--subject_id", type = "character", help = "Subject ID."),
   optparse::make_option("--library_id_tumor", type = "character", help = "Library ID of tumor."),
-  optparse::make_option("--csv_output", type = "character", help = "CSV output path (def: ./urls_<subject_id>__<library_id_tumor>.csv)."),
+  optparse::make_option("--csv_output", type = "character", help = "CSV output path."),
   optparse::make_option("--append", action = "store_true", help = "Append to existing file (or write to new one if file does not exist -- caution: no column headers are written).")
 )
 parser <- optparse::OptionParser(option_list = option_list, formatter = optparse::TitledHelpFormatter)
@@ -23,7 +23,7 @@ suppressMessages(library(rportal, include.only = "meta_umccrise"))
 suppressMessages(library(tidyr, include.only = c("pivot_longer", "unnest")))
 
 missing_flags <- NULL
-for (flag in c("subject_id", "library_id_tumor")) {
+for (flag in c("subject_id", "library_id_tumor", "csv_output")) {
   if (is.null(opt[[flag]])) {
     missing_flags <- c(missing_flags, flag)
   }
@@ -31,10 +31,6 @@ for (flag in c("subject_id", "library_id_tumor")) {
 if (length(missing_flags) > 0) {
   tmp <- paste(missing_flags, collapse = ", ")
   cli::cli_abort("Missing required flags: {tmp}")
-}
-
-if (is.null(opt[["csv_output"]])) {
-  opt[["csv_output"]] <- glue("urls_{opt[['subject_id']]}__{opt[['library_id_tumor']]}.csv")
 }
 
 if (is.null(opt[["append"]])) {

--- a/inst/scripts/datashare/datashare.R
+++ b/inst/scripts/datashare/datashare.R
@@ -5,10 +5,16 @@ option_list <- list(
   optparse::make_option("--subject_id", type = "character", help = "Subject ID."),
   optparse::make_option("--library_id_tumor", type = "character", help = "Library ID of tumor."),
   optparse::make_option("--csv_output", type = "character", help = "CSV output path."),
-  optparse::make_option("--append", action = "store_true", help = "Append to existing file (or write to new one if file does not exist -- caution: no column headers are written).")
+  optparse::make_option("--append", action = "store_true", help = "Append to existing file (or write to new one if file does not exist -- caution: no column headers are written)."),
+  optparse::make_option(c("--version", "-v"), action = "store_true", help = "Print rportal version and exit.")
 )
 parser <- optparse::OptionParser(option_list = option_list, formatter = optparse::TitledHelpFormatter)
 opt <- optparse::parse_args(parser)
+
+if (!is.null(opt[["version"]])) {
+  cat(as.character(packageVersion("rportal")), "\n")
+  quit("no", status = 0, runLast = FALSE)
+}
 
 # install following from UMCCR GitHub, rest are from CRAN
 # devtools::install_github("umccr/rportal")
@@ -98,7 +104,7 @@ envvar_undefined <- function() {
 env_und <- envvar_undefined()
 if (length(env_und) > 0) {
   e <- paste(env_und, collapse = ", ")
-  cli::cli_abort("Following AWS environment variables not defined: {e}")
+  cli::cli_abort("Following environment variables not defined: {e}")
 }
 
 


### PR DESCRIPTION
New usage (also see #7):

```
# keep the column headers with the first run
./datashare.R --subject_id SBJ03144 --library_id_tumor L2301290 --csv_output URL.csv 
# now append to same CSV
./datashare.R --subject_id SBJ04397 --library_id_tumor L2301291 --csv_output URL.csv --append
./datashare.R --subject_id SBJ04398 --library_id_tumor L2301292 --csv_output URL.csv --append
```

CSV looks like this btw:

```
sbjid_libid,type,bname,size,file_id,path,presigned_url
SBJ03144__L2301290,BAM_normal,PRJ231181_normal.bam,53.96G,fil.ef8476ef109e436cf42008dbe25f39c7,production/analysis_data/SBJ03144/wgs_tumor_normal/20231111f3791feb/L2301290_L2301298_dragen_somatic/PRJ231181_normal.bam,https://stratus-gds-aps2.s3.ap-southeast-2.amazonaws.com/...
```

Let me know if you'd like to get rid of any of the columns.