### PR TITLE
datashare: remove problematic json input string prior to parsing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,7 +5,7 @@
 ^README\.Rmd$
 ^\.DS_Store$
 ^\.Rproj\.user$
-^\.bumpversion\.cfg$
+^\.bumpversion\.toml$
 ^\.dockerignore$
 ^\.dvc$
 ^\.dvcignore$

--- a/R/datasharing.R
+++ b/R/datasharing.R
@@ -44,7 +44,7 @@ datashare_um <- function(sid, lid, token_ica = Sys.getenv("ICA_ACCESS_TOKEN")) {
     "REGEXP_LIKE(\"wfr_name\", 'umccr__automated__umccrise__{sid_lid}') ",
     "ORDER BY \"start\" DESC;"
   )
-  d_um_raw <- rportal::portaldb_query_workflow(query_um)
+  d_um_raw <- portaldb_query_workflow(query_um)
   n_um_runs <- nrow(d_um_raw)
   if (n_um_runs == 0) {
     cli::cli_abort("No umccrise results found for {sid_lid}")
@@ -58,7 +58,7 @@ datashare_um <- function(sid, lid, token_ica = Sys.getenv("ICA_ACCESS_TOKEN")) {
     )
     cli::cli_alert_info(msg)
   }
-  d_um_tidy <- rportal::meta_umccrise(d_um_raw)
+  d_um_tidy <- meta_umccrise(d_um_raw)
   um_dragen_input <- d_um_tidy[["gds_indir_dragen_somatic"]]
   stopifnot(!is.na(um_dragen_input))
 
@@ -67,11 +67,11 @@ datashare_um <- function(sid, lid, token_ica = Sys.getenv("ICA_ACCESS_TOKEN")) {
     "REGEXP_LIKE(\"wfr_name\", 'umccr__automated__wgs_tumor_normal__{sid_lid}') ",
     "ORDER BY \"start\" DESC;"
   )
-  d_tn_raw <- rportal::portaldb_query_workflow(query_tn)
+  d_tn_raw <- portaldb_query_workflow(query_tn)
   if (nrow(d_tn_raw) == 0) {
     cli::cli_abort("No wgs_tumor_normal results found for {sid_lid}")
   }
-  d_tn_tidy <- rportal::meta_wgs_tumor_normal(d_tn_raw)
+  d_tn_tidy <- meta_wgs_tumor_normal(d_tn_raw)
   n_tn_runs <- nrow(d_tn_tidy)
   if (n_tn_runs > 1) {
     if (um_dragen_input %in% d_tn_tidy[["gds_outdir_dragen_somatic"]]) {
@@ -208,7 +208,7 @@ datashare_wts <- function(sid, lid, wfrn_prefix = "umccr__automated__wts_tumor_o
     "REGEXP_LIKE(\"wfr_name\", '{wfrn_prefix}__{sid_lid}') ",
     "ORDER BY \"start\" DESC;"
   )
-  d_wts_raw <- rportal::portaldb_query_workflow(query_wts)
+  d_wts_raw <- portaldb_query_workflow(query_wts)
 
   n_wts_runs <- nrow(d_wts_raw)
   if (n_wts_runs == 0) {
@@ -238,7 +238,7 @@ datashare_wts <- function(sid, lid, wfrn_prefix = "umccr__automated__wts_tumor_o
   if (wfrn_prefix != "umccr__automated__wts_tumor_only") {
     d_wts_raw$input <- sub(x, "", d_wts_raw$input)
   }
-  d_wts_tidy <- rportal::meta_wts_tumor_only(d_wts_raw)
+  d_wts_tidy <- meta_wts_tumor_only(d_wts_raw)
   d_wts_urls1 <- d_wts_tidy[["gds_outdir_dragen"]] |>
     dracarys::gds_list_files_filter_relevant(
       token = token_ica, include_url = TRUE, page_size = 100, regexes = wts_files

--- a/inst/scripts/datashare/datashare.R
+++ b/inst/scripts/datashare/datashare.R
@@ -4,7 +4,10 @@ suppressMessages(library(optparse, include.only = "make_option"))
 option_list <- list(
   optparse::make_option("--subject_id", type = "character", help = "Subject ID."),
   optparse::make_option("--library_id_tumor", type = "character", help = "Library ID of tumor."),
-  optparse::make_option("--wts_wfrn_prefix", type = "character", help = "ICA Workflow Run Name prefix. Use if other than the default 'umccr__automated__wts_tumor_only'."),
+  optparse::make_option("--wts_wfrn_prefix",
+    type = "character", help = "ICA Workflow Run Name prefix. Use if other than the default.",
+    default = "umccr__automated__wts_tumor_only"
+  ),
   optparse::make_option("--wts", action = "store_true", type = "character", help = "This is a WTS library."),
   optparse::make_option("--csv_output", type = "character", help = "CSV output path."),
   optparse::make_option("--append", action = "store_true", help = "Append to existing file (or write to new one if file does not exist -- caution: no column headers are written)."),

--- a/inst/scripts/datashare/datashare.R
+++ b/inst/scripts/datashare/datashare.R
@@ -4,6 +4,7 @@ suppressMessages(library(optparse, include.only = "make_option"))
 option_list <- list(
   optparse::make_option("--subject_id", type = "character", help = "Subject ID."),
   optparse::make_option("--library_id_tumor", type = "character", help = "Library ID of tumor."),
+  optparse::make_option("--wts_wfrn_prefix", type = "character", help = "ICA Workflow Run Name prefix. Use if other than the default 'umccr__automated__wts_tumor_only'."),
   optparse::make_option("--wts", action = "store_true", type = "character", help = "This is a WTS library."),
   optparse::make_option("--csv_output", type = "character", help = "CSV output path."),
   optparse::make_option("--append", action = "store_true", help = "Append to existing file (or write to new one if file does not exist -- caution: no column headers are written)."),
@@ -16,7 +17,8 @@ opt <- optparse::parse_args(parser)
 #   library_id_tumor = "L2401254",
 #   wts = TRUE,
 #   csv_output = "FOO.csv",
-#   append = TRUE
+#   append = TRUE,
+#   wts_wfrn_prefix = "umccr__automated__wts_tumor_only"
 # )
 
 if (!is.null(opt[["version"]])) {
@@ -60,6 +62,7 @@ LibraryID_tumor <- opt[["library_id_tumor"]]
 csv_output <- opt[["csv_output"]]
 csv_append <- opt[["append"]]
 wts <- opt[["wts"]]
+wts_wfrn_prefix <- opt[["wts_wfrn_prefix"]]
 fs::dir_create(dirname(csv_output))
 cli::cli_alert_info("Start datasharing for {SubjectID}__{LibraryID_tumor}")
 
@@ -70,7 +73,7 @@ c("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION", "ICA_ACCESS_TOKEN"
 token_ica <- Sys.getenv("ICA_ACCESS_TOKEN") |> dracarys::ica_token_validate()
 
 if (wts) {
-  urls <- rportal::datashare_wts(sid = SubjectID, lid = LibraryID_tumor, token_ica = token_ica)
+  urls <- rportal::datashare_wts(sid = SubjectID, lid = LibraryID_tumor, wfrn_prefix = wts_wfrn_prefix, token_ica = token_ica)
 } else {
   urls <- rportal::datashare_um(sid = SubjectID, lid = LibraryID_tumor, token_ica = token_ica)
 }

--- a/inst/scripts/datashare/test.sh
+++ b/inst/scripts/datashare/test.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
-./datashare.R --subject_id SBJ03144 --library_id_tumor L2301290 --csv_output urls.csv
-./datashare.R --subject_id SBJ04397 --library_id_tumor L2301291 --csv_output urls.csv --append
+#./datashare.R --subject_id SBJ03144 --library_id_tumor L2301290 --csv_output urls.csv
+#./datashare.R --subject_id SBJ04397 --library_id_tumor L2301291 --csv_output urls.csv --append
 ./datashare.R --wts --subject_id SBJ05560 --library_id_tumor L2401254 --csv_output urls.csv --append
+./datashare.R --wts --subject_id SBJ05424 --library_id_tumor L2401135 --wts_wfrn_prefix umccr__atlas__wts_tumor_only --csv_output urls.csv --append

--- a/man/datashare_um.Rd
+++ b/man/datashare_um.Rd
@@ -4,7 +4,7 @@
 \alias{datashare_um}
 \title{Datashare umccrise Results}
 \usage{
-datashare_um(sid, lid, token_ica)
+datashare_um(sid, lid, token_ica = Sys.getenv("ICA_ACCESS_TOKEN"))
 }
 \arguments{
 \item{sid}{SubjectID.}
@@ -18,4 +18,11 @@ Tibble with presigned URLs.
 }
 \description{
 Datashare umccrise Results
+}
+\examples{
+\dontrun{
+sid <- "SBJ03144"
+lid <- "L2301290"
+datashare_um(sid, lid)
+}
 }

--- a/man/datashare_wts.Rd
+++ b/man/datashare_wts.Rd
@@ -4,12 +4,20 @@
 \alias{datashare_wts}
 \title{Datashare WTS Results}
 \usage{
-datashare_wts(sid, lid, token_ica)
+datashare_wts(
+  sid,
+  lid,
+  wfrn_prefix = "umccr__automated__wts_tumor_only",
+  token_ica = Sys.getenv("ICA_ACCESS_TOKEN")
+)
 }
 \arguments{
 \item{sid}{SubjectID.}
 
 \item{lid}{LibraryID of WTS tumor.}
+
+\item{wfrn_prefix}{ICA workflow run name prefix. Specify if you need something
+other than the default 'umccr__automated__wts_tumor_only'.}
 
 \item{token_ica}{ICA_ACCESS_TOKEN.}
 }
@@ -18,4 +26,11 @@ Tibble with presigned URLs.
 }
 \description{
 Datashare WTS Results
+}
+\examples{
+\dontrun{
+datashare_wts(sid = "SBJ05560", lid = "L2401254")
+datashare_wts(sid = "SBJ05424", lid = "L2401135", wfrn_prefix = "umccr__atlas__wts_tumor_only")
+}
+
 }

--- a/man/orca_libid2workflows.Rd
+++ b/man/orca_libid2workflows.Rd
@@ -34,6 +34,6 @@ Given a libraryId gets workflow details.
 token <- orca_jwt() |> jwt_validate()
 libid <- "L2401414"
 wf_name <- "cttsov2"
-d <- orca_libid2workflows(libid=libid, token=token, wf_name=wf_name)
+d <- orca_libid2workflows(libid = libid, token = token, wf_name = wf_name)
 }
 }


### PR DESCRIPTION
Fixes #24. Here we simply remove the problematic string prior to `jsonlite::fromJSON`ising (which happens inside `rportal::meta_wts_tumor_only`).